### PR TITLE
Fixed an issue with offsetExists throwing exception instead of returning false

### DIFF
--- a/Traits/ArrayPropertyAccess.php
+++ b/Traits/ArrayPropertyAccess.php
@@ -24,11 +24,15 @@ trait ArrayPropertyAccess
     /**
      * @param mixed $offset
      *
-     * @return mixed
+     * @return bool
      */
     public function offsetExists($offset)
     {
-        return property_exists($this, $this->getPropertyFromArrayKey($offset));
+        try {
+            return property_exists($this, $this->getPropertyFromArrayKey($offset));
+        } catch (\Exception $e) {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
```
Fatal error: Uncaught Exception: Cannot access or does not exists key [rows] in Directus\Database\Object\Column in /.../vendor/directus/utils/Traits/ArrayPropertyAccess.php on line 21

Exception: Cannot access or does not exists key [rows] in Directus\Database\Object\Column in /.../vendor/directus/utils/Traits/ArrayPropertyAccess.php on line 21

Call Stack:
    0.0003     356400   1. {main}()
    0.0118     818768   2. ...
    0.0861    3870528   3. ...
    0.0861    3870528   4. Directus\SDK\ClientLocal->getTable() ...:63
    0.1021    4202280   5. Directus\SDK\ClientLocal->createResponseFromData() /.../vendor/directus/sdk/src/ClientLocal.php:71
    0.1033    4216728   6. Directus\SDK\Response\Entry->__construct() /.../vendor/directus/sdk/src/AbstractClient.php:45
    0.1033    4216728   7. Directus\Database\Object\Column->offsetExists() /.../vendor/directus/sdk/src/Response/Entry.php:57
    0.1033    4216728   8. Directus\Database\Object\Column->getPropertyFromArrayKey() /.../vendor/directus/utils/Traits/ArrayPropertyAccess.php:31
```